### PR TITLE
gem install nokogiri

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This plugin adds a `{% wikipedia %}` tag that includes small boxes in your pages
 
 # Installation
 
+ * `$ gem install nokogiri`
  * Move `wikipedia.rb` and `wikipedia.html` into the `plugins` folder at the root of your octopress repo;
  * Move `_wikipedia.scss` into your theme's `sass/custom` dir (e.g. `.themes/custom/sass/custom`);
  * Move `w.png` into your theme's `source/images` dir;


### PR DESCRIPTION
install nokogiri first, otherwise `rake generate` will produce:

home/user/xyz/wikipedia.rb:2:in `require': cannot load such file -- nokogiri (LoadError)
