### PR TITLE
Point to correct example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This plugin adds a `{% wikipedia %}` tag that includes small boxes in your pages, containing Wikipedia article summaries. Here is [an example](http://pferreir.github.com/2012/06/19/medieval-mysteries/).
+This plugin adds a `{% wikipedia %}` tag that includes small boxes in your pages, containing Wikipedia article summaries. Here is [an example](http://pferreir.github.io/blog/2012/06/19/medieval-mysteries/).
 
 # Installation
 


### PR DESCRIPTION
Looks like you were migrated from `github.com` to `github.io`, and you also added a {% category %} to your post URL structure. :)
